### PR TITLE
D: travelpayouts.com

### DIFF
--- a/filters/general/adservers_block.txt
+++ b/filters/general/adservers_block.txt
@@ -184,7 +184,6 @@ gadspmz.com
 ||thstats.com$third-party
 ||thtrackingap.com
 ||tityx.com
-||travelpayouts.com
 ||truehits.in.th$third-party
 ||truehits.net$third-party
 ||tynt.com


### PR DESCRIPTION
https://www.travelpayouts.com offers a set of tools for webmasters in travel. All tools are useful and enrich content, so it's not banners (they are just the minority of tools our users embed to websites).

Banning the whole domain prevents Thai users from different search boxes on websites: flights, hotel, car search. We are happy to discuss all the matters.

Besides, Travelpayouts isn't presented in the global Adblock list.