### PR TITLE
Add piptrip.com

### DIFF
--- a/filters/general/adservers_block.txt
+++ b/filters/general/adservers_block.txt
@@ -142,6 +142,7 @@ gadspmz.com
 ||pc3ads.com
 ||ping-fast.com
 ||pingdom.net
+||piptrip.com
 ||pixeldigitalstudios.com
 ||plista.com
 ||popads.net


### PR DESCRIPTION
Requesting a site block on piptrip.com. The site mimics itself to be pantip.com and, redirects to ad sites ( possibly clickfraud too ).
This is my preliminary analysis on one of the URLs:

- The site manipulates Google Algorithm to display their site which morphs pantip.com (typosquatting) 
- The site limits 2 entry per IP, this ensures that VPN/Proxies/Analysis won't be in their way. (3+ attempts return code 500) 
- The site rotates exit URL every time you enter ( 1st and 2nd time ) 
- The site contains JS obfuscation which checks for location.ancestorOrigins == Array member of Piracy/Porn Sites before running its next payload 
- The site fakes HTTPS at its end stage, using trckfeed (dot) com certificate
- The website to be analysed ( Be minded that you only get 2 tries per IP, I wasted both tries, so prepare Wireshark and Chrome DevTools beforehand. ) : 
https:(doubleslash)piptrip(dot)com/topic/38053356 -- Link is without spaces and () ->changed as needed